### PR TITLE
Update hugo version due to debian:latest does not support Hugo versio…

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:latest
 MAINTAINER MoD <mod@kaigara.org>
 
-ENV HUGO_VERSION=0.17
+ENV HUGO_VERSION=0.25
 
 RUN apt-get update -y \
       && apt-get install -y \
@@ -11,7 +11,7 @@ RUN apt-get update -y \
 RUN wget -q https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
       tar xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
       rm -r hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
-      mv hugo_0.17_linux_amd64/hugo_0.17_linux_amd64 /usr/local/bin/hugo
+      mv hugo /usr/local/bin/hugo
 
 RUN groupadd web
 RUN useradd -g web -m web


### PR DESCRIPTION
hugo version was updated due to this errors on container start
```ERROR: 2018/01/09 11:12:33 hugo.go:421: Current theme does not support Hugo version 0.17. Minimum version required is 0.2
Started building sites ...
ERROR: 2018/01/09 11:12:33 template.go:477: template: theme/_default/__list.html:37: function "now" not defined
ERROR: 2018/01/09 11:12:33 template.go:477: template: theme/_default/single.html:33: function "now" not defined
ERROR: 2018/01/09 11:12:33 template.go:477: template: theme/index.html:35: function "now" not defined
ERROR: 2018/01/09 11:12:33 general.go:212: Error while rendering page license/index.md```
